### PR TITLE
Remove comments from REST API endpoints

### DIFF
--- a/comment-free-zone.php
+++ b/comment-free-zone.php
@@ -163,7 +163,7 @@ class Comment_Free_Zone {
 		}
 		if ( isset( $response->data['ping_status'] ) ) {
 			unset( $response->data['ping_status'] );
-		}	
+		}
 		$response->remove_link( 'replies' );
 
 		return $response;

--- a/comment-free-zone.php
+++ b/comment-free-zone.php
@@ -57,6 +57,20 @@ class Comment_Free_Zone {
 			999
 		);
 
+		// Disable comments REST API endpoint.
+		add_filter(
+			'rest_endpoints',
+			function ( $endpoints ) {
+				if ( isset( $endpoints['/wp/v2/comments'] ) ) {
+					unset( $endpoints['/wp/v2/comments'] );
+				}
+				if ( isset( $endpoints['/wp/v2/comments/(?P<id>[\d]+)'] ) ) {
+					unset( $endpoints['/wp/v2/comments/(?P<id>[\d]+)'] );
+				}
+				return $endpoints;
+			}
+		);
+
 		add_filter( 'manage_pages_columns', [ $this, 'remove_comments_column_from_pages' ] );
 		add_filter( 'comments_open', '__return_false', 20 );
 		add_filter( 'pings_open', '__return_false', 20 );
@@ -103,10 +117,7 @@ class Comment_Free_Zone {
 			}
 			$registry->unregister( 'core/' . $block );
 			// Filter the output of the block to be empty.
-			add_filter(
-				'render_block_core/' . $block,
-				'__return_empty_string'
-			);
+			add_filter( 'render_block_core/' . $block, '__return_empty_string' );
 		}
 
 		// Disable outgoing pings.
@@ -133,7 +144,29 @@ class Comment_Free_Zone {
 				remove_post_type_support( $post_type, 'comments' );
 				remove_post_type_support( $post_type, 'trackbacks' );
 			}
+
+			// Remove comment_data from REST API responses.
+			add_filter( 'rest_prepare_' . $post_type, [ $this, 'cleanup_rest_prepare_post_type' ] );
 		}
+	}
+
+	/**
+	 * Cleanup the REST API response for a post type.
+	 *
+	 * @param WP_REST_Response $response The response object.
+	 *
+	 * @return WP_REST_Response The modified response object.
+	 */
+	public function cleanup_rest_prepare_post_type( $response ) {
+		if ( isset( $response->data['comment_status'] ) ) {
+			unset( $response->data['comment_status'] );
+		}
+		if ( isset( $response->data['ping_status'] ) ) {
+			unset( $response->data['ping_status'] );
+		}	
+		$response->remove_link( 'replies' );
+
+		return $response;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -17,10 +17,10 @@ This plugin fully removes comments, trackbacks and all related features from you
 This plugin will:
 
 * In the admin:
-    * Remove the comments menu
-    * Remove the discussion settings page
-    * Remove the comments column from posts and pages
-    * Remove the comment section from the admin bar
+    * Removes the Comments menu item.
+    * Removes the Discussion settings page.
+    * Removes the comments column from posts and pages.
+    * Removes the comment section from the admin bar.
 * On the front-end:
     * Disable comments on all post types
     * Disable pingbacks and trackbacks


### PR DESCRIPTION
We'd still be exposing comments otherwise.